### PR TITLE
Pin GitHub Actions to full SHAs (PinnedOps)

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -8,8 +8,8 @@ jobs:
     name: push Buf modules to BSR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v1
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: bufbuild/buf-action@8f4a1456a0ab6a1eb80ba68e53832e6fcfacc16c
         with:
           format: false
           lint: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639
         with:
           go-version-file: ./go.mod
       - name: install tools

--- a/.github/workflows/release-jetbrains.yml
+++ b/.github/workflows/release-jetbrains.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
       # Set up Java environment for the next steps
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00
         with:
           distribution: zulu
           java-version: 17

--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -19,10 +19,10 @@ jobs:
           sudo npm -g install n
           sudo n stable
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639
         with:
           go-version-file: ./go.mod
       - name: extract version from tags
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
       - name: run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811
         with:
           distribution: goreleaser
           version: latest
@@ -41,7 +41,7 @@ jobs:
         env:
           VERSION: ${{ steps.meta.outputs.VERSION }}
       - name: release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
           draft: true
           generate_release_notes: true
@@ -52,7 +52,7 @@ jobs:
             ./dist/grpc-federation_*_*_*.tar.gz
             ./dist/grpc-federation_*_*_*.zip
       - name: publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@f4ece70f329f66686bd71c54b1671353fe320e49
         with:
           pat: ${{ secrets.AZURE_DEVOPS_ACCESS_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639
         with:
           go-version-file: ./go.mod
       - name: install tools
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: setup go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639
         with:
           go-version-file: ./go.mod
       - name: install tools
@@ -35,4 +35,4 @@ jobs:
       - name: run test
         run: make test
       - name: report coverage
-        uses: k1LoW/octocov-action@v1.4.0
+        uses: k1LoW/octocov-action@1ad702b3118b6a055c00b01db68ca0d9f6641dbc


### PR DESCRIPTION
### Purpose
Pin GitHub Actions to **full commit SHAs** (non-destructive).

### Evidence
- Diff HTML: /reports/diff/index.html
- Metrics: /reports/metrics.json
